### PR TITLE
Support for AWS lambda function

### DIFF
--- a/icinga2_api/defaults.py
+++ b/icinga2_api/defaults.py
@@ -1,6 +1,10 @@
 import os
 
-CONFIGFILE        = os.path.join(os.environ['HOME'], '.icinga2', 'api.yml') 
+if not 'HOME' in os.environ:
+  CONFIGFILE = 'api.yml'
+else:
+  CONFIGFILE = os.path.join(os.environ['HOME'], '.icinga2', 'api.yml')
+
 PROFILE           = 'default'
 READ_ACTION_URI   = '/v1/status'
 TIMEOUT           = 30


### PR DESCRIPTION
In AWS lambda environment, 'HOME' environment variable is not present. To fix this added a check in icinga2_api/defaults.py. 